### PR TITLE
fix for 1 file going missing everytime ;)

### DIFF
--- a/split_folders/split.py
+++ b/split_folders/split.py
@@ -130,7 +130,7 @@ def split_files(files, split_train, split_val, use_test):
     """Splits the files along the provided indices
     """
     files_train = files[:split_train]
-    files_val = files[split_train:split_val]
+    files_val = files[split_train:split_val] if use_test else files[split_train:]
 
     li = [(files_train, 'train'), (files_val, 'val')]
 


### PR DESCRIPTION
if only train / val is specified I always loose one file somewhere (which is due to the slicing logic). My minifix changes the slicing so that always all files get used following the same logic applied for the test folder part if no test folder is specified in the ratios.