### PR TITLE
Added compatibility for python <3.6 and fixed an error while running on windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ You you can use `split_folders` as Python module or as a Command Line Interface 
 
 If your datasets is balanced (each class has the same number of samples), choose `ratio` otherwise `fixed`. NB: oversampling is turned off by default.
 
+Run ```pip install tqdm``` for progress bar visualization.
+
 ### Module
 
 ```python
@@ -92,6 +94,23 @@ Options:
     --oversample enable oversampling of imbalanced datasets, works only with --fixed.
 Example:
     split_folders imgs --ratio .8 .1 .1
+    
+```
+
+### python -m
+
+```
+Usage : 
+    python -m split_folders -i <folder_with_images> -o <output> -r <ratio> -f <fixed> -s <seed> -os <oversample>
+Options:
+    Same as above with few minor additions.
+    -r => Ratio. : Default is `.8 .1 .1`, just pass -r for default values.
+    -f => Fixed  : Default is `100 100`, just pass -f for default values.
+Examples:
+    1) python -m split_folders -i imgs -f 2 2 -os      [In fixed mode and adds oversampling]
+    2) python -m split_folders -i imgs -o image_output -r .8 .2 -s 1923     [In ratio mode, outputs to image_output and sets seed to 1923]
+    3) python -m split_folders -i imgs -r       [Uses the default ratio]
+    4) python -m split_folders -i imgs -f       [Uses the default fixed values]
 ```
 
 ## License

--- a/split_folders/__main__.py
+++ b/split_folders/__main__.py
@@ -1,0 +1,44 @@
+from .split import *
+import argparse
+import sys
+
+if __name__=="__main__":
+	ap = argparse.ArgumentParser()
+	ap.add_argument("-r", "--ratio",nargs='*',type=float,
+	    help="The ratio to split. e.g. for train/val/test `.8 .1 .1` or for train/val `.8 .2`. Default is `.8 .1 .1`, just pass `-r` for default.")
+	ap.add_argument("-f", "--fixed",nargs='*',type=int,
+	    help="Set the absolute number of items per validation/test set. The remaining items constitute the training set. e.g. for train/val/test `100 100` or for train/val `100`. Default is `100 100`, just pass `-f` for default.")
+	ap.add_argument("-s", "--seed", type=int, default=1337,
+	    help="Set seed value for shuffling the items. defaults to 1337.")
+	ap.add_argument("-os", "--oversample",action='store_true',
+	    help="Enable oversampling of imbalanced datasets, works only with --fixed.")
+	ap.add_argument("-i", "--input", required=True,
+		help="The input folder path.")
+	ap.add_argument("-o", "--output", default='output',
+		help="Path to the output folder. defaults to `output`. Get created if non-existent.")
+	args = vars(ap.parse_args())
+	
+	#Check if ratio and fixed, both are not set
+	if '-r' not in sys.argv and '-f' not in sys.argv:
+		print("You need to chose either `ratio` or `fixed`")
+		quit()
+	#Check if ratio and fixed are both set
+	elif '-f' in sys.argv and '-r' in sys.argv:
+		print("You can not choose both, chose either `ratio` or `fixed`")
+		quit()	
+
+	if '-r' in sys.argv:
+		if args["oversample"]:
+			print("Oversampling will be ignored as it only works with `fixed`")
+		ratiovar = tuple(args["ratio"])
+		if len(ratiovar)<1:
+			ratiovar = [.8,.1,.1]
+		if len(ratiovar)==1:
+			print("You have to give more than one ratio value")
+			quit()
+		ratio(args["input"], output=args["output"], seed=args["seed"], ratio=ratiovar)
+	elif '-f' in sys.argv:
+		splitvar = tuple(args["fixed"])
+		if len(splitvar)<1:
+			splitvar = [100,100]
+		fixed(args["input"], output=args["output"], seed=args["seed"], fixed=splitvar, oversample=args["oversample"])


### PR DESCRIPTION
Hello, 
I was exploring your library this evening, which seemed very helpful. 
But after downloading, I couldn't get it to work and I was repeatedly getting this error : 
![image](https://user-images.githubusercontent.com/32819925/59151668-9dbff600-8a54-11e9-8808-d1899804eacf.png)

After a lot of experimenting with various things, I managed to fixed the error by adding a few lines to the main code ! 😄 

I ran the tests too, so here is the first test result (with no changes) : 
![image](https://user-images.githubusercontent.com/32819925/59151679-05764100-8a55-11e9-982e-89a4d5085ad9.png)

This is because f" ...." only works in Python 3.6 and above, so I changed that, and now it works in Python 3.5  
![image](https://user-images.githubusercontent.com/32819925/59151702-643bba80-8a55-11e9-8ca5-f5d62dc88e6d.png)

Then I ran the test again, this time I got this error : 
![image](https://user-images.githubusercontent.com/32819925/59151713-a533cf00-8a55-11e9-9aa1-d39eb5bdd761.png)

I don't know why this was happening, but anyway, I fixed it by converting them (the variables that were causing the errors) to string before using them in shutil.copy2 and others.

Finally, I ran the tests and : 
![image](https://user-images.githubusercontent.com/32819925/59151729-f8a61d00-8a55-11e9-9e51-620b529b030d.png)

Now, once everything was fixed, I was using this library to separate around 22Gb of data. Needless to say I needed to know how long it would take, so I added tqdm for progress bar visualization. If there's no tqdm, this library would still work perfectly. 

Lastly, I added a ```__main__.py``` file so that I can run the commands using ```python -m split_folders ...```. The file in bin folder needed to be added to an environment variable in windows before using it, so instead I made a direct way of using this library. 

Overall this is a fantastic library for me, and thank you for making it ! 😃  