### PR TITLE
Fixed error message in split_class_dir_fixed

### DIFF
--- a/splitfolders/split.py
+++ b/splitfolders/split.py
@@ -246,7 +246,7 @@ def split_class_dir_fixed(class_dir, output, fixed, seed, prog_bar, group_prefix
     """
     files = setup_files(class_dir, seed, group_prefix)
 
-    if not len(files) > sum(fixed):
+    if not len(files) >= sum(fixed):
         raise ValueError(
             f'The number of samples in class "{class_dir.stem}" are too few. There are only {len(files)} samples available but your fixed parameter {fixed} requires at least {sum(fixed)} files. You may want to split your classes by ratio.'
         )


### PR DESCRIPTION
if number of files is equal to sum of the fixed given by user, it should not throw an error message