### PR TITLE
added option to symlink (`ln -s`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ Occasionally, you may have things that comprise more than a single file (e.g. pi
 Set `group_prefix` to the length of the group (e.g. `2`).
 But now _all_ files should be part of groups.
 
-Set `move=True` if you want to move the files instead of copying.
-
+Set  
+- `move=True` or `move='move'` if you want to move the files instead of copying.
+- `move=False` or `move='copy'` if you want to copy the files. (default behavior)
+- `move='symlink'` if you want to symlink(i.e create shortcuts `ln -s`) instead of copying
 ### CLI
 
 ```
@@ -114,6 +116,7 @@ Options:
     --oversample    enable oversampling of imbalanced datasets, works only with --fixed.
     --group_prefix  split files into equally-sized groups based on their prefix
     --move          move the files instead of copying
+    --symlink       symlink(create shortcut) the files instead of copying
 Example:
     splitfolders --ratio .8 .1 .1 -- folder_with_images
 ```

--- a/splitfolders/cli.py
+++ b/splitfolders/cli.py
@@ -5,7 +5,7 @@ from .split import fixed, ratio
 
 def run():
     parser = argparse.ArgumentParser(
-        description="Split folders with files (e.g. images) into training, validation and test(dataset) folders."
+        description="Split folders with files (e.g. images) by copying them into training, validation and test(dataset) folders."
     )
     parser.add_argument(
         "--output",
@@ -41,10 +41,16 @@ def run():
         default=None,
         help="split files into equally-sized groups based on their prefix",
     )
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "--move",
         action="store_true",
         help="move the files instead of copying",
+    )
+    group.add_argument(
+        "--symlink",
+        action="store_true",
+        help="symlink(create shortcut) the files instead of copying",
     )
     parser.add_argument(
         "input",
@@ -53,6 +59,9 @@ def run():
 
     args = parser.parse_args()
 
+    if args.symlink:
+        args.move = 'symlink'
+    
     if args.ratio:
         ratio(
             args.input, args.output, args.seed, args.ratio, args.group_prefix, args.move


### PR DESCRIPTION
This solves #31.  The advantage of having symlinks (`ln -s`) is that we can just reference the dataset stored at some other place and create a folder structure at any/multiple desired locations as required by some codebases. Deleting symlinks doesn't delete the original dataset.  

The changes have been made to support backward compatibility of `move=True` and `move=False` along with the addition of `move='symlink'`. All tests have successfully passed.